### PR TITLE
#5 - control over cosmos repository

### DIFF
--- a/EasyCosmos/CosmosRepository.cs
+++ b/EasyCosmos/CosmosRepository.cs
@@ -15,12 +15,21 @@ namespace EasyCosmos
         private string collection;
         private string collectionLink;
 
-        public CosmosRepository(string database, string collection, string url, string key)
+        public CosmosRepository(string database, string collection, string url, string key) : this(database, collection)
         {
-            db = database;
-            this.collection = collection;
             Client = new DocumentClient(new Uri(url), key);
-            collectionLink = UriFactory.CreateDocumentCollectionUri(database, collection).ToString();
+        }
+
+        public CosmosRepository(string database, string collection, IDocumentClient client) : this(database, collection)
+        {
+            Client = client;
+        }
+
+        private CosmosRepository(string database, string collection)
+        {
+            this.db = database;
+            this.collection = collection;
+            this.collectionLink = UriFactory.CreateDocumentCollectionUri(database, collection).ToString();
         }
 
         public async Task CreateCollectionAsync()


### PR DESCRIPTION
fixes #5 by overloading the repositories constructor to allow for a custom ICosmosClient to be passed into it. The reasoning behind this is that CosmosClient has 7 overloaded constructors, it seems pointless in mapping each one of these in order to provide the same granular control over the client. Instead it makes more sense that if someone wants to follow this route that they create the client before creating the repository, that way they can config as require