### PR TITLE
#7 Enable cross partition reads

### DIFF
--- a/EasyCosmos/CosmosRepository.cs
+++ b/EasyCosmos/CosmosRepository.cs
@@ -45,7 +45,7 @@ namespace EasyCosmos
 
             try
             {
-                var query = Client.CreateDocumentQuery<T>(collectionLink)
+                var query = Client.CreateDocumentQuery<T>(collectionLink, new FeedOptions { EnableCrossPartitionQuery = true })
                       .Where(e => e.Type == entityTypeName)
                       .AsDocumentQuery();
 


### PR DESCRIPTION
#7 was caused by partition keys being required now on cosmos collections, if no partition key is provided than to read all documents a cross partition read is required. Since Easy Cosmos entities do not currently know of the partition key it is easier to read all versioned documents across partitions since we know there should only be one